### PR TITLE
Correct setup of VS solution on a clean PC

### DIFF
--- a/src/GitExtensions.EmptyPlugin/GitExtensions.EmptyPlugin.csproj
+++ b/src/GitExtensions.EmptyPlugin/GitExtensions.EmptyPlugin.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
@@ -29,7 +29,7 @@
 
   <!-- Before building project ensure we have debug GitExtensions instance (for references and debugging). -->
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="powershell.exe ..\..\tools\Download-GitExtensions.ps1" />
+    <Exec Command="powershell.exe -ExecutionPolicy Unrestricted ..\..\tools\Download-GitExtensions.ps1" />
   </Target>
 
   <!-- After build, copy plugin to debug GitExtensions instance (for debugging). -->

--- a/src/GitExtensions.EmptyPlugin/Properties/launchSettings.json
+++ b/src/GitExtensions.EmptyPlugin/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "GitExtensions.EmptyPlugin": {
+      "commandName": "Executable",
+      "executablePath": "$(SolutionDir)\\references\\GitExtensions\\GitExtensions.exe"
+    }
+  }
+}

--- a/tools/Download-GitExtensions.ps1
+++ b/tools/Download-GitExtensions.ps1
@@ -2,8 +2,8 @@ Set-Location $PSScriptRoot
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $ExtractRootPath = '../references'
-$AssetToDownloadName = 'GitExtensions-Portable-3.00.00.4433.zip';
-$AssetToDownloadUrl = 'https://github.com/gitextensions/gitextensions/releases/download/v3.00.00/GitExtensions-Portable-3.00.00.4433.zip';
+$AssetToDownloadName = 'GitExtensions-Portable-3.0.2.5232.zip';
+$AssetToDownloadUrl = 'https://github.com/gitextensions/gitextensions/releases/download/v3.0.2/GitExtensions-Portable-3.0.2.5232.zip';
 
 if (!($null -eq $AssetToDownloadUrl))
 {


### PR DESCRIPTION
This PR contains some changes that I found necessary and/or useful to successfully run EmptyPlugin on my PC:

1. PowerShell's default ExecutionPolicy would block the script `Download-GitExtensions.ps1`, since it is not signed. I bypassed it by explicitly setting the policy to Unrestricted when calling the script.
2. The VS solution didn't find the `GitExtensions.exe` and thus didn't run it. It is now added in `launchSettings.json`.

Plus:
3. Not really an issue, but I updated to the latest release GitExtensions 3.0.2.